### PR TITLE
Handle comments for postings

### DIFF
--- a/src/main/java/forum/controllers/ForumPostController.java
+++ b/src/main/java/forum/controllers/ForumPostController.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -40,18 +41,30 @@ public class ForumPostController {
 		return repository.save(posting);
 	}
 	
-	// by default Get all returns posts sorted with createDateTime DESC order
+	// by default Get all returns original posts (top level posts) sorted with createDateTime DESC order
 	@GetMapping(path = "/postings")
 	@ResponseStatus(HttpStatus.OK)
 	public List<Posting> getAllPosts(@RequestParam(value="userFirstName", defaultValue="") String userFirstName, 
 			  						 @RequestParam(value="userLastName", defaultValue="") String userLastName ) {
 		
+		
 		if(userFirstName != null && !userFirstName.isEmpty() 
 				&& userLastName != null && !userLastName.isEmpty()) {
+			
+			// return top level posts and plus comments by the user
 			return repository.findByUserFirstNameAndUserLastName(userFirstName, userLastName, new Sort(Sort.Direction.DESC,"createDateTime"));
 		}
 		
-	  return repository.findAll(new Sort(Sort.Direction.DESC,"createDateTime"));
+		// return only top level posts
+	    return repository.findOriginalPostingsOnly(new Sort(Sort.Direction.DESC,"createDateTime"));
+	}
+	
+	// by default Get all returns posts sorted with createDateTime DESC order
+	@GetMapping(path = "/postings/{id}/comments")
+	@ResponseStatus(HttpStatus.OK)
+	public List<Posting> getAllCommentsForAPost(@PathVariable("id") String originalPostingId ) {
+		
+	    return repository.findByOriginalPostingId(originalPostingId, new Sort(Sort.Direction.DESC,"createDateTime"));
 	}
 }
 

--- a/src/main/java/forum/document/Posting.java
+++ b/src/main/java/forum/document/Posting.java
@@ -9,6 +9,10 @@ public class Posting {
 	public String userFirstName;
 	public String userLastName;
 	public Date createDateTime;
+	
+	/* Original Post Id is used for postings that are comments. 
+	If null means that posting is original and not a comment. */
+	public String originalPostingId;
 
 	public Posting() {
 		
@@ -30,6 +34,15 @@ public class Posting {
 		this.userFirstName = userFirstName;
 		this.userLastName = userLastName;
 		this.createDateTime = createDateTime;
+	}
+	
+	public Posting(String messageBody, String userFirstName, String userLastName, Date createDateTime, String originalPostingId) {
+		super();
+		this.messageBody = messageBody;
+		this.userFirstName = userFirstName;
+		this.userLastName = userLastName;
+		this.createDateTime = createDateTime;
+		this.originalPostingId = originalPostingId;
 	}
 
 	public String getId() {
@@ -71,19 +84,32 @@ public class Posting {
 	public void setUserLastName(String userLastName) {
 		this.userLastName = userLastName;
 	}
-  
+
+	public String getOriginalPostId() {
+		return originalPostingId;
+	}
+
+	public void setOriginalPostId(String originalPostId) {
+		this.originalPostingId = originalPostId;
+	}
+
 	@Override
 	public String toString() {
 		return String.format(
-				"Customer[id=%s, messageBody='%s', createDateTime='%s']",
-				id, messageBody, createDateTime.toString());
+			"Posting[id=%s, messageBody='%s', userFirstName='%', userLastName='%', createDateTime='%s', 'originalPostingId'='%s']",
+			id, messageBody, userFirstName, userLastName, createDateTime.toString(), originalPostingId);
 	}
 
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
+		result = prime * result + ((createDateTime == null) ? 0 : createDateTime.hashCode());
+		result = prime * result + ((id == null) ? 0 : id.hashCode());
 		result = prime * result + ((messageBody == null) ? 0 : messageBody.hashCode());
+		result = prime * result + ((originalPostingId == null) ? 0 : originalPostingId.hashCode());
+		result = prime * result + ((userFirstName == null) ? 0 : userFirstName.hashCode());
+		result = prime * result + ((userLastName == null) ? 0 : userLastName.hashCode());
 		return result;
 	}
 
@@ -96,10 +122,35 @@ public class Posting {
 		if (getClass() != obj.getClass())
 			return false;
 		Posting other = (Posting) obj;
+		if (createDateTime == null) {
+			if (other.createDateTime != null)
+				return false;
+		} else if (!createDateTime.equals(other.createDateTime))
+			return false;
+		if (id == null) {
+			if (other.id != null)
+				return false;
+		} else if (!id.equals(other.id))
+			return false;
 		if (messageBody == null) {
 			if (other.messageBody != null)
 				return false;
 		} else if (!messageBody.equals(other.messageBody))
+			return false;
+		if (originalPostingId == null) {
+			if (other.originalPostingId != null)
+				return false;
+		} else if (!originalPostingId.equals(other.originalPostingId))
+			return false;
+		if (userFirstName == null) {
+			if (other.userFirstName != null)
+				return false;
+		} else if (!userFirstName.equals(other.userFirstName))
+			return false;
+		if (userLastName == null) {
+			if (other.userLastName != null)
+				return false;
+		} else if (!userLastName.equals(other.userLastName))
 			return false;
 		return true;
 	}

--- a/src/main/java/forum/repositroy/PostingRepository.java
+++ b/src/main/java/forum/repositroy/PostingRepository.java
@@ -5,13 +5,29 @@ import java.util.Optional;
 
 import org.springframework.data.domain.Sort;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 
 import forum.document.Posting;
 
 public interface PostingRepository extends MongoRepository<Posting, String> {
 
 	public Optional<Posting> findById(String id);
+
 	public List<Posting> findByMessageBody(String messageBody);
+
 	public List<Posting> findByUserFirstNameAndUserLastName(String userFirstName, String userLastName, Sort sort);
+
+	@Query("{'originalPostingId' : null}")
+	public List<Posting> findOriginalPostingsOnly(Sort sort);
+
+	/**
+	 * 
+	 * Finds comments for an original posting
+	 * @param originalPostingId
+	 * @param sort
+	 * @return
+	 */
+	public List<Posting> findByOriginalPostingId(String originalPostingId, Sort sort);
+
 	public List<Posting> findAll(Sort sort);
 }

--- a/src/test/java/forum/controllers/ForumPostControllerTest.java
+++ b/src/test/java/forum/controllers/ForumPostControllerTest.java
@@ -32,6 +32,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import forum.controllers.ForumPostController;
 import forum.document.Posting;
+import forum.repositroy.PostingRepository;
 
 @RunWith(SpringRunner.class)
 @WebMvcTest(ForumPostController.class)
@@ -44,12 +45,12 @@ public class ForumPostControllerTest {
 	 private PostingRepository repository;
 
 	 @Test
-	 public void savePosting() throws Exception {
+	 public void savePostingWithAllFields() throws Exception {
 		 
 		 Posting newPostingRequest = new Posting("someMsg");
 		 String newPostingRequestJsonStr = asJsonString(newPostingRequest);
 		 
-		 Posting mockPostingResult = new Posting("someMsg", null, null, new Date());
+		 Posting mockPostingResult = new Posting("someMsg", "Tia", "Koko", new Date(), "12345");
 		 mockPostingResult.setId("123");
  
 		 when(repository.save(any(Posting.class))).thenReturn(mockPostingResult);
@@ -64,7 +65,10 @@ public class ForumPostControllerTest {
 			      .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
 			      .andExpect(jsonPath("$.messageBody").value("someMsg"))
 		 		  .andExpect(jsonPath("$.id").value("123"))
-		          .andExpect(jsonPath("$.createDateTime").isNotEmpty());
+		 		  .andExpect(jsonPath("$.userFirstName").value("Tia"))
+		 		  .andExpect(jsonPath("$.userLastName").value("Koko"))
+		          .andExpect(jsonPath("$.createDateTime").isNotEmpty())
+		          .andExpect(jsonPath("$.originalPostId").value("12345"));
 	 }
 	 
 	 @Test
@@ -132,7 +136,7 @@ public class ForumPostControllerTest {
 		            new Posting("hello world", "Tia", "Koko", new Date()),
 		            new Posting("hello world Again", "Yeye", "Miambo", new Date()));
 		 
-		 when(repository.findAll(any(Sort.class))).thenReturn(postings);
+		 when(repository.findOriginalPostingsOnly(any(Sort.class))).thenReturn(postings);
 		 
 		 mockMvc.perform(get("/postings"))
 		 		.andDo(print())
@@ -146,7 +150,7 @@ public class ForumPostControllerTest {
 	            .andExpect(jsonPath("$[1].userFirstName", is("Yeye")))
 	            .andExpect(jsonPath("$[1].userLastName", is("Miambo")));
 		 
-		 verify(repository, times(1)).findAll(any(Sort.class));
+		 verify(repository, times(1)).findOriginalPostingsOnly(any(Sort.class));
 		 verifyNoMoreInteractions(repository);
 	 }
 	 
@@ -180,7 +184,7 @@ public class ForumPostControllerTest {
 				 	new Posting("hello world", "Tia", "Koko", new Date()),
 		            new Posting("hello world Again", "Yeye", "Miambo", new Date()));
 		 
-		 when(repository.findAll(any(Sort.class))).thenReturn(postings);
+		 when(repository.findOriginalPostingsOnly(any(Sort.class))).thenReturn(postings);
 		 
 		 mockMvc.perform(get("/postings").param("userFirstName", "Tia"))
 		 		.andDo(print())
@@ -194,7 +198,7 @@ public class ForumPostControllerTest {
 	            .andExpect(jsonPath("$[1].userFirstName", is("Yeye")))
 	            .andExpect(jsonPath("$[1].userLastName", is("Miambo")));
 		 
-		 verify(repository, times(1)).findAll(any(Sort.class));
+		 verify(repository, times(1)).findOriginalPostingsOnly(any(Sort.class));
 		 verifyNoMoreInteractions(repository);
 	 }
 	 
@@ -204,7 +208,7 @@ public class ForumPostControllerTest {
 				 	new Posting("hello world", "Tia", "Koko", new Date()),
 		            new Posting("hello world Again", "Yeye", "Miambo", new Date()));
 		 
-		 when(repository.findAll(any(Sort.class))).thenReturn(postings);
+		 when(repository.findOriginalPostingsOnly(any(Sort.class))).thenReturn(postings);
 		 
 		 mockMvc.perform(get("/postings").param("userLastName", "Koko"))
 		 		.andDo(print())
@@ -218,7 +222,7 @@ public class ForumPostControllerTest {
 	            .andExpect(jsonPath("$[1].userFirstName", is("Yeye")))
 	            .andExpect(jsonPath("$[1].userLastName", is("Miambo")));
 		 
-		 verify(repository, times(1)).findAll(any(Sort.class));
+		 verify(repository, times(1)).findOriginalPostingsOnly(any(Sort.class));
 		 verifyNoMoreInteractions(repository);
 	 }
 	 
@@ -228,7 +232,7 @@ public class ForumPostControllerTest {
 				 	new Posting("hello world", "Tia", "Koko", new Date()),
 		            new Posting("hello world Again", "Yeye", "Miambo", new Date()));
 		 
-		 when(repository.findAll(any(Sort.class))).thenReturn(postings);
+		 when(repository.findOriginalPostingsOnly(any(Sort.class))).thenReturn(postings);
 		 
 		 mockMvc.perform(get("/postings")
 				.param("userFirstName", "Tia")
@@ -244,7 +248,7 @@ public class ForumPostControllerTest {
 	            .andExpect(jsonPath("$[1].userFirstName", is("Yeye")))
 	            .andExpect(jsonPath("$[1].userLastName", is("Miambo")));
 		 
-		 verify(repository, times(1)).findAll(any(Sort.class));
+		 verify(repository, times(1)).findOriginalPostingsOnly(any(Sort.class));
 		 verifyNoMoreInteractions(repository);
 	 }
 	 
@@ -254,7 +258,7 @@ public class ForumPostControllerTest {
 				 	new Posting("hello world", "Tia", "Koko", new Date()),
 		            new Posting("hello world Again", "Yeye", "Miambo", new Date()));
 		 
-		 when(repository.findAll(any(Sort.class))).thenReturn(postings);
+		 when(repository.findOriginalPostingsOnly(any(Sort.class))).thenReturn(postings);
 		 
 		 mockMvc.perform(get("/postings")
 				.param("userFirstName", "")
@@ -270,7 +274,31 @@ public class ForumPostControllerTest {
 	            .andExpect(jsonPath("$[1].userFirstName", is("Yeye")))
 	            .andExpect(jsonPath("$[1].userLastName", is("Miambo")));
 		 
-		 verify(repository, times(1)).findAll(any(Sort.class));
+		 verify(repository, times(1)).findOriginalPostingsOnly(any(Sort.class));
+		 verifyNoMoreInteractions(repository);
+	 }
+	 
+	 @Test
+	 public void findAllCommentsForAPosting() throws Exception {
+		 List<Posting> comments= Arrays.asList(
+				 	new Posting("hello world", "Tia", "Koko", new Date(), "1234"),
+		            new Posting("hello world Again", "Yeye", "Miambo", new Date(), "1234"));
+		 
+		 when(repository.findByOriginalPostingId(any(String.class), any(Sort.class))).thenReturn(comments);
+		 
+		 mockMvc.perform(get("/postings/{id}/comments", "1234"))
+		 		.andDo(print())
+		 		.andExpect(status().isOk())
+	            .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))
+	            .andExpect(jsonPath("$", hasSize(2)))
+	            .andExpect(jsonPath("$[0].messageBody", is("hello world")))
+	            .andExpect(jsonPath("$[0].userFirstName", is("Tia")))
+	            .andExpect(jsonPath("$[0].userLastName", is("Koko")))
+	            .andExpect(jsonPath("$[1].messageBody", is("hello world Again")))
+	            .andExpect(jsonPath("$[1].userFirstName", is("Yeye")))
+	            .andExpect(jsonPath("$[1].userLastName", is("Miambo")));
+		 
+		 verify(repository, times(1)).findByOriginalPostingId(any(String.class), any(Sort.class));
 		 verifyNoMoreInteractions(repository);
 	 }
 	 

--- a/src/test/java/forum/repository/PostingRepositoryTest.java
+++ b/src/test/java/forum/repository/PostingRepositoryTest.java
@@ -24,7 +24,7 @@ public class PostingRepositoryTest {
 	@Autowired
 	PostingRepository repository;
 
-	Posting majorPost, minorPost, miscPost;
+	Posting majorPost, minorPost, miscPost, majorPostComment, miscPostComment1, miscPostComment2;
 
 	@Before
 	public void setUp() {
@@ -34,8 +34,14 @@ public class PostingRepositoryTest {
 		majorPost = repository.save(new Posting("major post!", "Yeye", "Miambo", new Date()));
 		minorPost = repository.save(new Posting("minor post!", "Tia", "Koko", new Date()));
 		miscPost = repository.save(new Posting("misc post!", "Tia", "Koko", new Date()));
-	}
+		
+		majorPostComment = repository.save(new Posting("Major post comment", "Lulu", "Aqua", new Date(), majorPost.getId()));
+		
+		miscPostComment1 = repository.save(new Posting("comment to misc posting", "Joo", "Doo", new Date(), miscPost.getId()));
+		miscPostComment2 = repository.save(new Posting("comment2 to misc", "Xib", "Alba", new Date(), miscPost.getId()));
 
+	}
+	
 	@Test
 	public void setsIdOnSave() {
 
@@ -114,8 +120,22 @@ public class PostingRepositoryTest {
 	
 	@Test
 	public void findsAllSortedByCreateDateTime() {
-		
+
 		List<Posting> result = repository.findAll(new Sort(Sort.Direction.DESC,"createDateTime"));
+		assertThat(result.get(0).getCreateDateTime()).isAfter(result.get(1).getCreateDateTime());
+	}
+	
+	@Test
+	public void findAllOriginalPostingsOnly() {
+		List<Posting> result = repository.findOriginalPostingsOnly(new Sort(Sort.Direction.DESC,"createDateTime"));
+		assertThat(result).hasSize(3);
+		assertThat(result.get(0).getCreateDateTime()).isAfter(result.get(1).getCreateDateTime());
+	}
+	
+	@Test
+	public void findCommentsForACertainOriginalPost() {
+		List<Posting> result = repository.findByOriginalPostingId(miscPost.getId(), new Sort(Sort.Direction.DESC,"createDateTime"));
+		assertThat(result).hasSize(2);
 		assertThat(result.get(0).getCreateDateTime()).isAfter(result.get(1).getCreateDateTime());
 	}
 }


### PR DESCRIPTION
A comment is essentially a Posting entity with an extra field, here
defined as OriginalPostingId, to hold the Id of the Posting it is
a comment for.

Add repository methods to find comments for a Posting Id and
modified the getAll controller to only return top level
postings for cases where findAll() was previously invoked.

Modifed and extended tests.